### PR TITLE
Apertium API keys not used any more

### DIFF
--- a/docs/admin/machine.rst
+++ b/docs/admin/machine.rst
@@ -35,8 +35,8 @@ limited set of languages.
 
 The recommended way how to use Apertium is to run own Apertium APy server.
 
-Alternatively you can use Apertium server, but you should get API key from
-them, otherwise number of requests is rate limited.
+Alternatively you can use https://www.apertium.org/apy if you don't expect 
+to make too many requests.
 
 To enable this service, add ``weblate.trans.machine.apertium.ApertiumAPYTranslation`` to
 :setting:`MACHINE_TRANSLATION_SERVICES`.


### PR DESCRIPTION
The old api (see http://wiki.apertium.org/wiki/Old_Apertium_web_service ) required keys, but the new one doesn't (it might in the future, but we haven't had any abuse so far). The old service might still run, sometimes, but it's recommended to either run your own APY server or use https://www.apertium.org/apy/ for single-users

Before submitting pull request, please ensure that:

- [ ] Every commit has message which describes it
- [ ] Every commit is needed on it's own, if you have just minor fixes to previous commits, you can squash them
- [ ] Any code changes come with testcase
- [ ] Any new functionality is covered by user documentation
